### PR TITLE
treat galen erroutput as debug info

### DIFF
--- a/tasks/galen.js
+++ b/tasks/galen.js
@@ -286,7 +286,7 @@ module.exports = function (grunt) {
               throw new Error("Cannot find Galenframework at " + localCommand);
             }
           }
-          
+
           var command = [
             galenCliAvailable ? 'galen' : localCommand,
             'test',
@@ -313,18 +313,17 @@ module.exports = function (grunt) {
                   debug('Got following deprecation warnings: ' + erroutput.yellow);
 
                 } else {
-                  log('failed'.red);
-                  reports.push(erroutput);
+                  debug('Got following debug infos: ' + erroutput.yellow);
                 }
-              } else {
-                if (isFailed(output)) {
-                  log('failed'.red);
-                } else {
-                  log('done'.green);
-                }
-                reports.push(output);
-                return cb();
               }
+
+              if (isFailed(output)) {
+                log('failed'.red);
+              } else {
+                log('done'.green);
+              }
+              reports.push(output);
+              return cb();
             }
           });
         };


### PR DESCRIPTION
Hello Martin,

there is a problem running a grunt-galenframework task with chrome or phantom. Galen process (or selenium under the hood) seems to output debug info as error. See erroutput parameter of the callback passed to exec method of child_process package in runGalenTests() (tasks/galen.js line 302) `... childprocess.exec(command, function (err, output, erroutput) { ...`

E.g. running chrome there is following  erroutput:

```
Starting ChromeDriver 2.21.371459 (36d3d07f660ff2bc1bf28a75d1cdabed0983e7c4) on port 14913
Only local connections are allowed.

```

It is obviously an info but is treated in code as error. Strictly speaking this is correct, as the third parameter of callback means _stderr_ (https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback). However it fails the test run. So I just let output this info as debug message.

I hope you'll like the fix or adapt it so that chrome and phantom work well.
Thanks! ;)

P.S.: I use Mac OS X El Capitan
